### PR TITLE
Add support for custom polls

### DIFF
--- a/src/emodus/gen.py
+++ b/src/emodus/gen.py
@@ -276,6 +276,20 @@ def get_specific_collection_list(ride_attributes, discipline_id, collection_name
     # Return None or an empty list if no match is found
     return None
 
+def get_discourse_poll(ride_attributes, discipline_id, collection_name):
+    """
+    Returns the discourse_poll value for a specific discipline and collection name.
+    """
+    ride_groups = ride_attributes.get("ride_groups", [])
+    for ride in ride_groups:
+        if ride.get("discipline_id") == discipline_id:
+            collections = ride.get("group_collections", [])
+            for collection in collections:
+                current_name = collection.get("name", "")
+                if current_name.strip().lower() == collection_name.strip().lower():
+                    return collection.get("discourse_poll", ride_attributes["templates"]["default_poll"])
+    return ride_attributes["templates"]["default_poll"]
+
 def get_group_name_as_list(ride_attributes, discipline_id):
     # Locate the discipline
     discipline = next((d for d in ride_attributes.get("ride_groups", [])
@@ -399,10 +413,8 @@ def get_start_location(locations, selected_discipline):
 def main():
     # Check if 'DEBUG' environment variable exists
     ride_attributes = load_ride_attributes("ride_attributes.yml")
-    # Load secrets
-    with open("secrets.yml", "r") as file:
-        secrets = yaml.safe_load(file)
-    locations = secrets.get("locations", [])
+    secrets = load_ride_attributes("secrets.yml")
+    #locations = secrets.get("locations", [])
 
     with open("ride_template.md", "r") as file:
         ride_template = file.read()
@@ -443,9 +455,10 @@ def main():
     # Assemble estimated pace for all groups of selected cultures
     if is_group_collection is True:
         list_of_groups = get_specific_member_groups(ride_attributes, selected_discipline["id"], selected_culture["name"])
+        discourse_poll = get_discourse_poll(ride_attributes, selected_discipline["id"], selected_culture["name"])
     else:
         list_of_groups = get_group_name_as_list(ride_attributes, selected_discipline["id"])
-    print(list_of_groups)
+    logger.debug(f"List of groups: {list_of_groups}")
     estimated_pace_string = format_group_paces(ride_attributes, selected_discipline["id"], list_of_groups, ride_date)
     #def format_group_paces(ride_attributes, discipline_id, selected_groups, ride_date)
 
@@ -453,7 +466,7 @@ def main():
     approx_distance = input("\nEnter the approximate distance in km: ")
 
     # Get User Input for Start Location
-    full_start_location, start_location_name = get_start_location(locations, selected_discipline["id"])
+    full_start_location, start_location_name = get_start_location(secrets.get("locations", []), selected_discipline["id"])
 
     # Get User Input for Routes
     route_description = collect_multiline_input("\nEnter the route URLs with any descriptors (press Enter twice to finish):\n")
@@ -500,6 +513,7 @@ def main():
     output_content = output_content.replace("PROMPT_FOR_ROUTE", "\n".join(route_description))
     output_content = output_content.replace("PROMPT_FOR_DESCRIPTION", ride_description_text)
     output_content = output_content.replace("PROMPT_FOR_NOTES", ride_notes)
+    output_content = output_content.replace("RIDE_ATTRIBUTES_DISCOURSE_POLL", discourse_poll)
     output_content = output_content.replace("RIDE_ATTRIBUTES_YML_RIDE_FOOTER", ride_attributes["ride_footer"])
 
     print("\nGenerated Ride Description:\n")

--- a/src/emodus/ride_attributes.yml
+++ b/src/emodus/ride_attributes.yml
@@ -3,6 +3,14 @@
 #
 # Waterloo Cycling Club - Master Ride Configuration
 
+templates:
+  default_poll: &default_poll |
+    [poll type=regular results=always public=true chartType=bar]
+    * ✅ Going
+    * 🤔 Interested
+    * ❌ Not going
+    [/poll]
+
 # Ride Disciplines
 disciplines:
   - id: cx
@@ -67,10 +75,20 @@ ride_groups:
         description: "Groups G1 through G4."
         member_groups: ["G1", "G2", "G3", "G4"]
         member_cultures: ["Fast", "Intermediate"]
+        discourse_poll: *default_poll
+
       - name: "G5 & Rec"
         description: "G5 & Rec"
         member_groups: ["G5", "Rec"]
         member_cultures: ["Rec"]
+        discourse_poll: |
+          [poll name=rec_and_g5 type=regular results=always public=true chartType=bar]
+          * ✅ Going Rec
+          * ✅ Going G5
+          * 🤔 Interested Rec
+          * 🤔 Interested G5
+          * ❌ Not going
+          [/poll]
     groups:
       - name: "G1"
         description: |

--- a/src/emodus/ride_template.md
+++ b/src/emodus/ride_template.md
@@ -22,10 +22,6 @@ PROMPT_FOR_DESCRIPTION
 
 PROMPT_FOR_NOTES
 
-[poll type=regular results=always public=true chartType=bar]
-* ✅ Going
-* 🤔 Interested
-* ❌ Not going
-[/poll]
+RIDE_ATTRIBUTES_DISCOURSE_POLL
 
 RIDE_ATTRIBUTES_YML_RIDE_FOOTER

--- a/tests/test_get_discourse_poll.py
+++ b/tests/test_get_discourse_poll.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from emodus.gen import get_discourse_poll
+
+class TestGetDiscoursePoll(unittest.TestCase):
+
+    def setUp(self):
+        self.ride_attributes = {
+            "templates": {
+                "default_poll": "Default Poll Content"
+            },
+            "ride_groups": [
+                {
+                    "discipline_id": "road",
+                    "group_collections": [
+                        {
+                            "name": "A Group",
+                            "discourse_poll": "A Group Poll"
+                        },
+                        {
+                            "name": "B Group",
+                            "discourse_poll": "B Group Poll"
+                        }
+                    ]
+                },
+                {
+                    "discipline_id": "gravel",
+                    "group_collections": [
+                        {
+                            "name": "Gravel Grinders",
+                            "discourse_poll": "Gravel Group Poll"
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def test_get_discourse_poll_found(self):
+        # Test case where the discourse_poll is found for a discipline and collection
+        result = get_discourse_poll(self.ride_attributes, "road", "A Group")
+        self.assertEqual(result, "A Group Poll")
+
+    def test_get_discourse_poll_found_case_insensitive(self):
+        # Test case with case-insensitive collection name
+        result = get_discourse_poll(self.ride_attributes, "road", "a group")
+        self.assertEqual(result, "A Group Poll")
+
+    def test_get_discourse_poll_not_found_collection(self):
+        # Test case where collection name is not found
+        result = get_discourse_poll(self.ride_attributes, "road", "Non Existent Group")
+        self.assertEqual(result, self.ride_attributes["templates"]["default_poll"])
+
+    def test_get_discourse_poll_not_found_discipline(self):
+        # Test case where discipline_id is not found
+        result = get_discourse_poll(self.ride_attributes, "mtb", "Any Group")
+        self.assertEqual(result, self.ride_attributes["templates"]["default_poll"])
+
+    def test_get_discourse_poll_no_group_collections(self):
+        # Test case with a discipline that has no group_collections
+        ride_attributes_no_collections = {
+            "templates": {
+                "default_poll": "Default Poll Content"
+            },
+            "ride_groups": [
+                {
+                    "discipline_id": "road",
+                    "group_collections": []
+                }
+            ]
+        }
+        result = get_discourse_poll(ride_attributes_no_collections, "road", "A Group")
+        self.assertEqual(result, self.ride_attributes["templates"]["default_poll"])
+
+    def test_get_discourse_poll_no_ride_groups(self):
+        # Test case with no ride_groups at all
+        ride_attributes_empty = {"ride_groups": [],
+                                 "templates": {
+                                     "default_poll": "Default Poll Content"
+                                 }
+                                }
+        result = get_discourse_poll(ride_attributes_empty, "road", "A Group")
+        self.assertEqual(result, self.ride_attributes["templates"]["default_poll"])
+
+    def test_get_discourse_poll_missing_discourse_poll_key(self):
+        # Test case where discourse_poll key is missing for a matching collection
+        ride_attributes_missing_key = {
+            "ride_groups": [
+                {
+                    "discipline_id": "road",
+                    "group_collections": [
+                        {
+                            "name": "C Group",
+                        }
+                    ]
+                }
+            ],
+            "templates": {
+                "default_poll": "Default Poll Content"
+            }
+        }
+        result = get_discourse_poll(ride_attributes_missing_key, "road", "C Group")
+        self.assertEqual(result, self.ride_attributes["templates"]["default_poll"])
+
+    def test_get_discourse_poll_default_poll_returned_if_not_found(self):
+        # Test case where no specific poll is found, and default_poll should be returned
+        result = get_discourse_poll(self.ride_attributes, "road", "Non Existent Collection")
+        self.assertEqual(result, self.ride_attributes["templates"]["default_poll"])
+
+    def test_get_discourse_poll_default_poll_returned_if_discipline_not_found(self):
+        # Test case where discipline is not found, and default_poll should be returned
+        result = get_discourse_poll(self.ride_attributes, "non_existent_discipline", "Any Group")
+        self.assertEqual(result, self.ride_attributes["templates"]["default_poll"])
+


### PR DESCRIPTION
- Add support to ride_attributes.yml
  - Add default_poll template
  - Add discourse_poll to group_collections
  - Add the poll normally used for rec & g5
- Add get_discourse_poll to gen.py
  - For group_collection, return specified poll, otherwise default
- Remove poll from ride_template.md and replace placeholder with
desired poll
- Use load_ride_attributes to load secrets

Resolves #13
