### PR TITLE
Use Discourse pre-fill URL to populate details

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,33 @@ Download the following files from GitHub:
     - ride_attributes.yml
     - ride_template.md
 
-## Running
+## How to Create a New Topic in the Waterloo Cycling Club Discourse Forum
 
-- Move to the folder where you downloaded the eModus files
-- Activate virtual environment as in "Setup" section above.
-- `python gen.py`
+Follow these steps to use the eModus tool to automate your topic creation.
 
-Note: if you would like to enable debug logging set debugging:
+### 1. Preparation
+* **Collect URLs:** Have the links for your routes ready to paste.
+* **Open Terminal:** Open your Command Prompt (Windows) or Terminal (macOS or Linux).
+
+### 2. Launch the Tool
+
+Navigate to your eModus folder and start the application:
+
+1.  **Enter the folder:** Use the `cd` command to move into the directory where you downloaded the files.
+2.  **Activate the environment:** Run the activation command from the "Setup" guide (this ensures the tool has the right permissions to run).
+3.  **Start the script:** Type the following and press **Enter**:
+    ```bash
+    python gen.py
+    ```
+### 3. Complete the Form
+
+* **Follow Prompts:** The terminal will ask you for specific information. Type or paste your details as requested.
+* **Automated Browser:** Once the info is entered, **gen.py** will automatically open your web browser and fill in the fields for you. 
+* **Select Discipline:** Look for the "Tag" section in the browser and manually select the correct **Ride Discipline**.
+
+### 4. Review and Submit
+* **Check Your Work:** Briefly review the information the script populated in the browser to ensure everything looks correct.
+* **Publish:** Click the **Create topic** button at the bottom of the page to finish.
+
+Note to Developers: if you would like to enable debug logging set debugging:
 - Linux: `DEBUG=1 python gen.py`

--- a/src/emodus/gen.py
+++ b/src/emodus/gen.py
@@ -20,6 +20,8 @@ import logging
 import os
 import re
 from datetime import datetime, timedelta, time
+from urllib.parse import quote
+import webbrowser
 import yaml
 
 # Define the logger that was missing
@@ -458,6 +460,7 @@ def main():
         discourse_poll = get_discourse_poll(ride_attributes, selected_discipline["id"], selected_culture["name"])
     else:
         list_of_groups = get_group_name_as_list(ride_attributes, selected_discipline["id"])
+        discourse_poll = ride_attributes["templates"]["default_poll"]
     logger.debug(f"List of groups: {list_of_groups}")
     estimated_pace_string = format_group_paces(ride_attributes, selected_discipline["id"], list_of_groups, ride_date)
     #def format_group_paces(ride_attributes, discipline_id, selected_groups, ride_date)
@@ -483,8 +486,12 @@ def main():
     day_of_month = ride_date.strftime("%d")
     year = ride_date.strftime("%Y")
 
-    title = f"{day_of_week} {selected_culture["name"]} {month} {day_of_month}, {start_time.strftime("%I:%M %p")} at {start_location_name}"
-    logger.debug(f"Ride title: {title}")
+    title = (
+        f"{day_of_week} {selected_culture["name"]} "
+        f"{selected_discipline["name"]} Ride {month} {day_of_month}, "
+        f"{start_time.strftime("%I:%M %p")} at {start_location_name}"
+    )
+    logger.debug("Ride title: %s", title)
 
     output_content = ride_template.replace("DAY_OF_WEEK", day_of_week)
     output_content = output_content.replace("MONTH", month)
@@ -501,7 +508,7 @@ def main():
         # It's an individual group. Prompt for group name.
         culture_string = "[" + selected_culture["name"] +\
             "](" + selected_culture["url"] + ")"
-    logger.debug(f"culture_string: {culture_string}")
+    logger.debug("culture_string: %s", culture_string)
     output_content = output_content.replace("RIDE_ATTRIBUTES_YML_CULTURES_INFO", culture_string)
     if approx_distance.strip() == "":
         approx_distance = " See proposed route"
@@ -518,6 +525,19 @@ def main():
 
     print("\nGenerated Ride Description:\n")
     print(output_content)
+
+    url_title_string = quote(title)
+    url_body_string = quote(output_content)
+    logger.debug("URL title: %s", url_title_string)
+
+    create_ride_url = (
+        f"https://forum.waterloocyclingclub.ca/new-topic?title={url_title_string}"
+        f"&body={url_body_string}"
+        f"&category=ride-planning-signup"
+        f"&tags={selected_discipline}"
+    )
+    webbrowser.open(create_ride_url)
+
 
     with open("generated_ride_description.md", "w") as output_file:
         output_file.write(output_content)


### PR DESCRIPTION
Utilize Discourse pre-filled URL to populate details for ride:
- Use urllib.parse.quote to encode strings for URL
- Use webbrowser.open to launch web page and populate it

Enhance README.me with more user friendly instructions and note
about specifying tags.

Fix bugs:
- Ensure discourse_poll is always defined
- Flush out title and enhance title order
- Change from f-strings for some logger strings
- Shorten some long lines

Note:
- Tags are not working as expected. See #27

Resolves #4
